### PR TITLE
Remove gem version constraints for compatibility with ArchivesSpace v4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ ASpaceGems.setup if defined? ASpaceGems
 
 source 'https://rubygems.org'
 
-gem "write_xlsx", "1.01.0"
+gem "write_xlsx"


### PR DESCRIPTION
 Tested the plugin with ArchivesSpace v4.2.0-RC1 and had to remove the write_xlsx gem version constraint to make it work.

Observed error:

```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.

You specified: write_xlsx (= 1.01.0) and write_xlsx (>= 0). Bundler cannot continue.


 #  from /archivesspace/data/tmp/jetty-0_0_0_0-8089-backend_war-_-any-11254950831087414322/webapp/WEB-INF/Gemfile:66

 #  -------------------------------------------

 #  gem "actionmailer", '~> 6.1.6'

 >  gem "write_xlsx"

 #  

 #  -------------------------------------------


	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:282:in `add_dependency'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:101:in `gem'

	from /archivesspace/data/tmp/jetty-0_0_0_0-8089-backend_war-_-any-11254950831087414322/webapp/WEB-INF/Gemfile:66:in `(eval)'

	from org/jruby/RubyBasicObject.java:2550:in `instance_eval'

	from org/jruby/RubyBasicObject.java:2563:in `instance_eval'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:47:in `block in eval_gemfile'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:315:in `with_gemfile'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:45:in `eval_gemfile'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/dsl.rb:12:in `evaluate'

	from /archivesspace/gems/gems/bundler-2.6.9/lib/bundler/definition.rb:39:in `build'

```